### PR TITLE
Fix edgecase where node is laying in coordinates 0,00000

### DIFF
--- a/coordinates.go
+++ b/coordinates.go
@@ -15,6 +15,9 @@ func deltaEncodeCoordinates(lats, lngs []float64) (granularity int32, latOffset,
 	for _, f := range l {
 		a := int64(f * 1e9)
 		g := int64(1)
+		if a == 0 {
+			continue
+		}
 		for {
 			if a/10*10 == a {
 				g *= 10


### PR DESCRIPTION
Hi!

I got an edgecase when processing a node laying on the exact 0.0000000°.
This would drive the could into an infinity loop. Adding the continue fixes the problem.

KR
Michiel